### PR TITLE
Quote string messages in URL for Android

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -60,7 +60,7 @@
      * Executes event/command/jsFunction in webView.
      */
     WebViewInterface.prototype._executeJS = function(strJSFunction){
-        var url = 'javascript:'+strJSFunction;
+        var url = 'javascript:' + encodeURIComponent(strJSFunction);
         this.webView.android.loadUrl(url);
     };
     


### PR DESCRIPTION
Previously, if you sent a string message with `"` in it, it would
not be quoted and the javascript would fail.
