### PR TITLE
Use evaluateJavascript instead of loadUrl for Android where possible

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,6 @@
- var common = require("./index-common");
- 
+ const common = require("./index-common");
+ const platformModule = require("platform");
+
  global.moduleMerge(common, exports);
  
  /**
@@ -72,8 +73,12 @@
      * Executes event/command/jsFunction in webView.
      */
     WebViewInterface.prototype._executeJS = function(strJSFunction){
-        var url = 'javascript:'+strJSFunction;
-        this.webView.android.loadUrl(url);
+      if (platformModule.device.sdkVersion >= 19) {
+        this.webView.android.evaluateJavascript(strJSFunction, null);
+      }
+      else {
+        this.webView.android.loadUrl('javascript:'+strJSFunction);
+      }
     };
     
     return WebViewInterface;


### PR DESCRIPTION
Using loadUrl [will fail if the event data gets too big](https://stackoverflow.com/questions/37688010/webview-loadurl-exceeds-2097152-characters). In our case we had to transport some base64 images from photo library and we got errors from chromium complaining about the url size.

This will be used only on api level >= 19, as this is not available under this api level.

Maybe the docs should also be updated to warn of the emit's eventData size limitations for future travelers 😃 