### PR TITLE
fix(android): switch to evaluateJavascript instead of loadUrl

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -72,8 +72,11 @@
      * Executes event/command/jsFunction in webView.
      */
     WebViewInterface.prototype._executeJS = function(strJSFunction){
-        var url = 'javascript:'+strJSFunction;
-        this.webView.android.loadUrl(url);
+        this.webView.android.evaluateJavascript(strJSFunction, new android.webkit.ValueCallback({
+            onReceiveValue: function(value) {
+                console.log(value);
+            }
+        }));
     };
     
     return WebViewInterface;


### PR DESCRIPTION
targetSdkVersion in manifest is now 19+ ( base on chromium ). loadUrl can't load long strings now
https://developer.android.com/guide/webapps/migrating.html.

Using evaluateJavascript() enables you to send long strings to the webview again