### PR TITLE
Fix: Android crashs on call to _onWebViewEvent()

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -14,7 +14,9 @@
         onWebViewEvent: function(webViewId, eventName, jsonData){
             // getting webviewInterface object by webViewId from static map.
             var oWebViewInterface = getWebViewIntefaceObjByWebViewId(webViewId);
-            oWebViewInterface._onWebViewEvent(eventName, jsonData);
+            if (oWebViewInterface) {
+                oWebViewInterface._onWebViewEvent(eventName, jsonData);
+            }
         }
     });
     


### PR DESCRIPTION
I stress tested my app using:

```bash
adb shell monkey -p com.organization.app -c android.intent.category.LAUNCHER --kill-process-after-error -v 10000
```

It crashed quite often on the following line:

```js
oWebViewInterface._onWebViewEvent(eventName, jsonData);
```

telling me that a call to `_onWebViewEvent` on `undefined` was not possible.

This Pull Request fixes the crashing.